### PR TITLE
feat: add cron-based status reminder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "pek-cfp-slackbot",
-	"scripts": {
-		"dev": "wrangler dev",
-		"deploy": "wrangler deploy --minify",
-		"cf-typegen": "wrangler types --env-interface CloudflareBindings",
+  "name": "pek-cfp-slackbot",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy --minify",
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings",
     "lint": "eslint --ext .ts src",
-		"format": "prettier --write src"
-	},
-	"dependencies": {
-		"@kitsuyaazuma/hono-slack-verify": "^0.1.0",
-		"hono": "^4.7.11",
-		"zod": "^3.25.61"
-	},
-	"devDependencies": {
-		"@eslint/js": "^9.29.0",
-		"eslint": "^9.29.0",
-		"eslint-config-prettier": "^10.1.5",
-		"prettier": "^3.5.3",
-		"typescript-eslint": "^8.34.1",
-		"wrangler": "^4.19.1"
-	},
-	"packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
+    "format": "prettier --write src"
+  },
+  "dependencies": {
+    "@kitsuyaazuma/hono-slack-verify": "^0.1.0",
+    "hono": "^4.7.11",
+    "zod": "^3.25.61"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.29.0",
+    "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.5",
+    "prettier": "^3.5.3",
+    "typescript-eslint": "^8.34.1",
+    "wrangler": "^4.19.1"
+  },
+  "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 import { Hono } from "hono";
 import events from "./routes/events";
+import { scheduled } from "./scheduled";
 
 const app = new Hono();
 
 app.route("/events", events);
 
-export default app;
+export default {
+  fetch: app.fetch,
+  scheduled,
+};

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -9,7 +9,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.use("*", verifySlackRequest());
 
-const formatValidationErrors = (error: z.ZodError) => {
+export const formatValidationErrors = (error: z.ZodError) => {
   let message = "❌ プロポーザルの内容に以下の問題が見つかりました\n\n";
   for (const issue of error.issues) {
     message += `• ${issue.message}\n`;
@@ -65,7 +65,7 @@ app.post("/", async (c) => {
     }
   }
 
-  await postSlackMessage(c.env.SLACK_BOT_TOKEN, channel, ts, slackMessage);
+  await postSlackMessage(c.env.SLACK_BOT_TOKEN, channel, slackMessage, ts);
   return c.text("OK", 200);
 });
 

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -1,0 +1,80 @@
+import { formatValidationErrors } from "./routes/events";
+import { Bindings } from "./types";
+import { validateAllProposals } from "./utils/fortee";
+import { postSlackMessage } from "./utils/slack";
+import { z } from "zod";
+
+export const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  _controller: ScheduledController,
+  env: Bindings,
+  _ctx: ExecutionContext,
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+) => {
+  const validationResultsWithInfo = await validateAllProposals();
+
+  if (validationResultsWithInfo.length === 0) {
+    console.error(
+      "プロポーザルが見つからなかったか、取得に失敗したため処理を終了します",
+    );
+    return;
+  }
+
+  const validProposals = validationResultsWithInfo.filter((v) => v.success);
+  const invalidProposals = validationResultsWithInfo.filter((v) => !v.success);
+
+  let summaryMessage = "📣 *CFPステータスチェック*\n\n";
+  summaryMessage += validationResultsWithInfo
+    .map(({ success }) => {
+      return success ? "🟩" : "🟥";
+    })
+    .join("");
+  summaryMessage += `\n\n*合計: ${validationResultsWithInfo.length}件、有効: ${validProposals.length}件、無効: ${invalidProposals.length}件*`;
+
+  const res = await postSlackMessage(
+    env.SLACK_BOT_TOKEN,
+    env.SLACK_STATUS_CHECK_CHANNEL,
+    summaryMessage,
+  );
+  const resJson = await res.json<{
+    ok: boolean;
+    ts: string;
+    error?: string;
+  }>();
+  if (!resJson.ok) {
+    console.error(`Slackへのメッセージ送信に失敗しました：${resJson.error}`);
+    return;
+  }
+
+  const thread_ts = resJson.ts;
+
+  for (const { error, uuid } of invalidProposals) {
+    if (uuid === undefined) {
+      continue;
+    }
+    let threadMessage = `https://fortee.jp/platform-engineering-kaigi-2025/proposal/${uuid}`;
+    if (error instanceof z.ZodError) {
+      threadMessage += `\n\n${formatValidationErrors(error)}`;
+
+      let oncallUser = await env.PROPOSAL_ONCALL_KV.get(uuid);
+      if (oncallUser === null) {
+        const users = env.PROPOSAL_ONCALL_USERS.split(",")
+          .map((user) => user.trim())
+          .filter((user) => user !== "");
+        if (users.length > 0) {
+          oncallUser = users[Math.floor(Math.random() * users.length)];
+          env.PROPOSAL_ONCALL_KV.put(uuid, oncallUser);
+        }
+      }
+      threadMessage += `\n<@${oncallUser}> さん、内容の確認をお願いします！🙏`;
+    } else {
+      threadMessage += `\n\n🚨 エラーが発生しました\n\n${error.message}`;
+    }
+    await postSlackMessage(
+      env.SLACK_BOT_TOKEN,
+      env.SLACK_STATUS_CHECK_CHANNEL,
+      threadMessage,
+      thread_ts,
+    );
+  }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type Bindings = {
   SLACK_SIGNING_SECRET: string;
   PROPOSAL_ONCALL_KV: KVNamespace;
   PROPOSAL_ONCALL_USERS: string;
+  SLACK_STATUS_CHECK_CHANNEL: string;
 };
 
 export type SlackAppMentionEvent = {

--- a/src/utils/fortee.ts
+++ b/src/utils/fortee.ts
@@ -183,3 +183,58 @@ export const validateProposal = async (
     };
   }
 };
+
+const ApiResponseUuidSchema = z.object({
+  proposals: z.array(z.object({ uuid: z.string().uuid() })),
+});
+
+export type ValidationResultWithInfo = ValidationResult & { uuid?: string };
+
+export const validateAllProposals = async (): Promise<
+  ValidationResultWithInfo[]
+> => {
+  const apiUrl = `https://fortee.jp/platform-engineering-kaigi-2025/api/proposals`;
+
+  try {
+    const response = await fetch(apiUrl);
+    if (!response.ok) {
+      return [
+        {
+          success: false,
+          error: new Error(
+            `APIリクエストに失敗しました（スタータス：${response.status}）`,
+          ),
+        },
+      ];
+    }
+
+    const data = await response.json();
+    const validationResult = ApiResponseUuidSchema.safeParse(data);
+
+    if (!validationResult.success) {
+      return [{ success: false, error: validationResult.error }];
+    }
+
+    const results: ValidationResult[] = [];
+    for (const proposal of validationResult.data.proposals) {
+      const result: ValidationResultWithInfo = await validateProposal(
+        proposal.uuid,
+      );
+      if (!result.success) {
+        result.uuid = proposal.uuid;
+      }
+      results.push(result);
+    }
+    return results;
+  } catch (error) {
+    return [
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? error
+            : new Error("不明なエラーが発生しました"),
+      },
+    ];
+  }
+};

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,19 +1,23 @@
 export const postSlackMessage = async (
   token: string,
   channel: string,
-  thread_ts: string,
   text: string,
-) => {
-  await fetch("https://slack.com/api/chat.postMessage", {
+  thread_ts?: string,
+): Promise<Response> => {
+  const body: Record<string, unknown> = {
+    channel: channel,
+    text: text,
+  };
+  if (thread_ts) {
+    body.thread_ts = thread_ts;
+  }
+  const res = await fetch("https://slack.com/api/chat.postMessage", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({
-      channel: channel,
-      thread_ts: thread_ts,
-      text: text,
-    }),
+    body: JSON.stringify(body),
   });
+  return res;
 };


### PR DESCRIPTION
## WHAT

This PR implements a scheduled job (cron trigger) to report on the status of all proposals.

- This job fetches all proposals from the fortee API and validates each one against the existing Zod schema.
- A summary report is posted to a designated Slack channel, showing the status (🟩 for valid, 🟥 for invalid) of every proposal.
- For each invalid proposal, a detailed message is posted in a thread, including the specific validation errors and a mention of an assigned on-call person for review.

## WHY

This feature provides proactive and automated visibility into the status of all submitted proposals. By regularly checking and reporting on their validity, we can:

- Quickly identify proposals that have issues (e.g., missing required labels, exceeding character limits).
- Streamline the review process by automatically assigning team members to follow up on invalid submissions.
- Ensure all proposals are complete and correct ahead of the CFP deadline, reducing last-minute work and potential issues.