### PR TITLE
feat: add interactive button to change pending status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono";
 import events from "./routes/events";
+import interactivity from "./routes/interactivity";
 import { scheduled } from "./scheduled";
 
 const app = new Hono();
 
 app.route("/events", events);
+app.route("/interactivity", interactivity);
 
 export default {
   fetch: app.fetch,

--- a/src/routes/interactivity.ts
+++ b/src/routes/interactivity.ts
@@ -1,0 +1,71 @@
+import { Hono } from "hono";
+import { Bindings } from "../types";
+import { BlockActionPayloadSchema, updateSlackMessage } from "../utils/slack";
+import { validateProposal } from "../utils/fortee";
+import { verifySlackRequest } from "@kitsuyaazuma/hono-slack-verify";
+import {
+  setProposalStatusPending,
+  setProposalStatusUnpending,
+  handleInvalidProposal,
+} from "../utils/proposals";
+
+const app = new Hono<{ Bindings: Bindings }>();
+
+app.use("*", verifySlackRequest());
+
+app.post("/", async (c) => {
+  const body = await c.req.text();
+  const payload = new URLSearchParams(body).get("payload");
+  if (!payload) {
+    return c.text("Bad Request: Missing payload", 400);
+  }
+  const bloackActionPayload = BlockActionPayloadSchema.parse(
+    JSON.parse(payload.toString()),
+  );
+
+  if (bloackActionPayload.type === "block_actions") {
+    for (const action of bloackActionPayload.actions) {
+      if (
+        action.action_id === "pending_proposal" ||
+        action.action_id === "unpending_proposal"
+      ) {
+        const uuid = action.value;
+        if (action.action_id === "pending_proposal") {
+          await setProposalStatusPending(c.env.PROPOSAL_ONCALL_KV, uuid);
+        } else if (action.action_id === "unpending_proposal") {
+          await setProposalStatusUnpending(c.env.PROPOSAL_ONCALL_KV, uuid);
+        }
+
+        const result = await validateProposal(uuid);
+        let slackMessage = "";
+        let blocks: Record<string, unknown>[] | undefined = undefined;
+        if (result.success) {
+          const { proposal } = result;
+          slackMessage = `✅ プロポーザルの内容は有効です\n\n*タイトル* : ${proposal.title}\n*スピーカー* : ${proposal.speaker.name}`;
+        } else {
+          const { threadMessage, blocks: _blocks } =
+            await handleInvalidProposal(c.env, uuid, result.error);
+          slackMessage = threadMessage;
+          blocks = _blocks;
+        }
+        await updateSlackMessage(
+          c.env.SLACK_BOT_TOKEN,
+          bloackActionPayload.channel.id,
+          bloackActionPayload.message.ts,
+          slackMessage,
+          blocks,
+        );
+        return c.text("OK", 200);
+      }
+    }
+  }
+
+  return c.text("OK", 200);
+});
+
+app.onError((err, c) => {
+  console.error("Error in interactivity route:", err);
+  return c.text("Internal Server Error", 500);
+});
+
+export default app;

--- a/src/utils/proposals.ts
+++ b/src/utils/proposals.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import { Bindings } from "../types";
+
+export const PENDING_PROPOSAL_PREFIX = "PENDING:";
+
+export const formatValidationErrors = (error: z.ZodError) => {
+  let message = "❌ プロポーザルの内容に以下の問題が見つかりました\n\n";
+  for (const issue of error.issues) {
+    message += `• ${issue.message}\n`;
+  }
+  return message;
+};
+
+export const handleInvalidProposal = async (
+  env: Bindings,
+  uuid: string,
+  error: z.ZodError | Error,
+) => {
+  let threadMessage = `https://fortee.jp/platform-engineering-kaigi-2025/proposal/${uuid}`;
+  let blocks: Record<string, unknown>[] | undefined = undefined;
+
+  if (error instanceof z.ZodError) {
+    threadMessage += `\n\n${formatValidationErrors(error)}`;
+
+    let oncallUser = await env.PROPOSAL_ONCALL_KV.get(uuid);
+    if (
+      oncallUser === null ||
+      oncallUser.replace(PENDING_PROPOSAL_PREFIX, "") === ""
+    ) {
+      const users = env.PROPOSAL_ONCALL_USERS.split(",")
+        .map((user) => user.trim())
+        .filter((user) => user !== "");
+      if (users.length > 0) {
+        oncallUser = users[Math.floor(Math.random() * users.length)];
+        await env.PROPOSAL_ONCALL_KV.put(uuid, oncallUser);
+      }
+    }
+
+    if (oncallUser?.startsWith(PENDING_PROPOSAL_PREFIX)) {
+      const pendingUserId = oncallUser.replace(PENDING_PROPOSAL_PREFIX, "");
+      threadMessage += `\n<@${pendingUserId}> さんが保留中です！⛔️`;
+      blocks = [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: threadMessage,
+          },
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "保留を解除する",
+              },
+              style: "primary",
+              value: uuid,
+              action_id: "unpending_proposal",
+            },
+          ],
+        },
+      ];
+    } else if (oncallUser) {
+      threadMessage += `\n<@${oncallUser}> さん、内容の確認をお願いします！🙏`;
+      blocks = [
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: threadMessage,
+          },
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "保留中にする",
+              },
+              style: "danger",
+              value: uuid,
+              action_id: "pending_proposal",
+            },
+          ],
+        },
+      ];
+    }
+  } else {
+    threadMessage += `\n\n🚨 エラーが発生しました\n\n${error.message}`;
+  }
+
+  return { threadMessage, blocks };
+};
+
+export const setProposalStatusPending = async (
+  kv: KVNamespace,
+  uuid: string,
+): Promise<void> => {
+  const userId = await kv.get(uuid);
+  if (userId === null || userId === "") {
+    await kv.put(uuid, PENDING_PROPOSAL_PREFIX);
+  } else if (!userId.startsWith(PENDING_PROPOSAL_PREFIX)) {
+    await kv.put(uuid, PENDING_PROPOSAL_PREFIX + userId);
+  }
+};
+
+export const setProposalStatusUnpending = async (
+  kv: KVNamespace,
+  uuid: string,
+): Promise<void> => {
+  const userId = await kv.get(uuid);
+  if (userId === null || userId === "") {
+    return;
+  } else if (userId.startsWith(PENDING_PROPOSAL_PREFIX)) {
+    await kv.put(uuid, userId.replace(PENDING_PROPOSAL_PREFIX, ""));
+  }
+};

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,17 +1,68 @@
+import { z } from "zod";
+
+const SLACK_API_URL = "https://slack.com/api";
+
+export const BlockActionPayloadSchema = z.object({
+  type: z.literal("block_actions"),
+  actions: z.array(
+    z.object({
+      action_id: z.string(),
+      value: z.string(),
+    }),
+  ),
+  message: z.object({
+    text: z.string(),
+    ts: z.string(),
+  }),
+  channel: z.object({
+    id: z.string(),
+  }),
+});
+
 export const postSlackMessage = async (
   token: string,
   channel: string,
   text: string,
+  blocks?: Record<string, unknown>[],
   thread_ts?: string,
 ): Promise<Response> => {
   const body: Record<string, unknown> = {
     channel: channel,
     text: text,
   };
+  if (blocks) {
+    body.blocks = blocks;
+  }
   if (thread_ts) {
     body.thread_ts = thread_ts;
   }
-  const res = await fetch("https://slack.com/api/chat.postMessage", {
+  const res = await fetch(`${SLACK_API_URL}/chat.postMessage`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return res;
+};
+
+export const updateSlackMessage = async (
+  token: string,
+  channel: string,
+  ts: string,
+  text: string,
+  blocks?: Record<string, unknown>[],
+): Promise<Response> => {
+  const body: Record<string, unknown> = {
+    channel,
+    ts,
+    text,
+  };
+  if (blocks) {
+    body.blocks = blocks;
+  }
+  const res = await fetch(`${SLACK_API_URL}/chat.update`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## WHAT

This PR introduces a new Slack interactivity endpoint (`/interactivity`) to manage proposal statuses. Users can now mark a proposal as "pending" or "unpending" directly from a Slack message.

Additionally, some duplicated logic has been refactored into shared utility functions to improve code maintainability.

## WHY

This feature streamlines the process of reviewing and updating a proposal's status. Previously, as noted in #7, there was no way to add or change the pending status after the initial check. This workflow enhances the system's flexibility.