### PR TITLE
feat: trigger cloudflare pages deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ pnpm run dev
 ## Deployment
 
 ```bash
+pnpm wrangler kv namespace create PROPOSAL_ONCALL_KV
+
 pnpm run deploy
-# pnpm wrangler kv namespace create PROPOSAL_ONCALL_KV
+
 pnpm wrangler secret put SLACK_BOT_TOKEN
 pnpm wrangler secret put SLACK_SIGNING_SECRET
 pnpm wrangler secret put PROPOSAL_ONCALL_USERS
 pnpm wrangler secret put SLACK_STATUS_CHECK_CHANNEL
+pnpm wrangler secret put CLOUDFLARE_PAGES_DEPLOY_HOOK_URL
+pnpm wrangler secret put TRIGGER_USER_ID
 ```
 
 ## Type Generation

--- a/src/routes/events.ts
+++ b/src/routes/events.ts
@@ -4,6 +4,7 @@ import { postSlackMessage } from "../utils/slack";
 import { validateProposal, getUuidFromMessage } from "../utils/fortee";
 import { verifySlackRequest } from "@kitsuyaazuma/hono-slack-verify";
 import { handleInvalidProposal } from "../utils/proposals";
+import { triggerCloudflarePagesDeploy } from "../utils/cloudflare";
 
 const app = new Hono<{ Bindings: Bindings }>();
 
@@ -21,7 +22,11 @@ app.post("/", async (c) => {
   }
 
   const { event } = body;
-  const { text, channel, ts } = event;
+  const { text, channel, ts, user } = event;
+
+  if (user === c.env.TRIGGER_USER_ID) {
+    await triggerCloudflarePagesDeploy(c.env, channel, ts);
+  }
 
   const uuid = getUuidFromMessage(text);
   if (uuid === null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export type Bindings = {
   PROPOSAL_ONCALL_KV: KVNamespace;
   PROPOSAL_ONCALL_USERS: string;
   SLACK_STATUS_CHECK_CHANNEL: string;
+  CLOUDFLARE_PAGES_DEPLOY_HOOK_URL?: string;
+  TRIGGER_USER_ID?: string;
 };
 
 export type SlackAppMentionEvent = {

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -33,5 +33,12 @@ export const triggerCloudflarePagesDeploy = async (
     }
   } catch (err) {
     console.error("Error triggering Cloudflare Pages deploy:", err);
+    await postSlackMessage(
+      env.SLACK_BOT_TOKEN,
+      channel,
+      `❌ Cloudflare Pagesのデプロイ中にエラーが発生しました：${err}`,
+      undefined,
+      ts,
+    );
   }
 };

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -1,0 +1,37 @@
+import { Bindings } from "../types";
+import { postSlackMessage } from "./slack";
+
+export const triggerCloudflarePagesDeploy = async (
+  env: Bindings,
+  channel: string,
+  ts: string,
+) => {
+  if (!env.CLOUDFLARE_PAGES_DEPLOY_HOOK_URL) {
+    console.error("CLOUDFLARE_PAGES_DEPLOY_HOOK_URL is not set.");
+    return;
+  }
+  try {
+    const response = await fetch(env.CLOUDFLARE_PAGES_DEPLOY_HOOK_URL, {
+      method: "POST",
+    });
+    if (response.ok) {
+      await postSlackMessage(
+        env.SLACK_BOT_TOKEN,
+        channel,
+        "🚀 Cloudflare Pagesのデプロイをトリガーしました",
+        undefined,
+        ts,
+      );
+    } else {
+      await postSlackMessage(
+        env.SLACK_BOT_TOKEN,
+        channel,
+        `❌ Cloudflare Pagesのデプロイに失敗しました：${response.statusText}`,
+        undefined,
+        ts,
+      );
+    }
+  } catch (err) {
+    console.error("Error triggering Cloudflare Pages deploy:", err);
+  }
+};


### PR DESCRIPTION
## WHAT

This PR adds a new function `triggerCloudflarePagesDeploy` to trigger a Cloudflare Pages deployment via a deploy hook URL. If a message is from a specific user (identified by `TRIGGER_USER_ID`), it triggers a new Cloudflare Pages deployment.

## WHY

The PEK website is built with Astro, and proposal information is embedded as static content at build time. Therefore, it is important to quickly reflect any updates to the proposals on the website. 
This feature streamlines the process by allowing deployments to be triggered directly from Slack, ensuring the latest information is always available without needing to deploy manually or periodically.